### PR TITLE
Add option u; skip mvn dep:analyze

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -127,6 +127,7 @@ testArgumentHelp() {
 		  -i pattern    Filter dependencies using pattern. Syntax is
 		                [groupId]:[artifactId]:[type]:[version]
 		  -o filename   Write output to file
+		  -u            Don't check all undeclared dependencies
 		  -q            Quiet
 	EOF
     assertEquals "$expected" "$out"


### PR DESCRIPTION
If there are many undeclared third party dependencies,
the graph can be overwhelming, especially since
these dependencies are not affected by the -i patther filter option.