### PR TITLE
Fix bug multiple uses same line

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -251,6 +251,7 @@ usages() {
     | while IFS=$'\t' read id base src resource ;do
         find "$base" \( -path "$src/*" -or -path "$resource/*" \) -type f \
             -exec fgrep --color=never --binary-files=without-match -H -o -f "$TMPDIR/packages.txt" {} \; \
+            | clean_up_fgrep \
             | awk -F: 'BEGIN { OFS = "\t" } {
                         d[1] = "'"$src"'"; d[2] = "'"$resource"'"
                         for (s in d) {
@@ -293,6 +294,18 @@ usages() {
             }' \
         | sort \
         > "$outfile"
+}
+
+clean_up_fgrep() {
+    awk -F: '{
+        OFS = FS
+        if (NF == 2) {
+            f = $1
+            print
+        }
+        else
+            print f, $0
+    }'
 }
 
 mvneval() {

--- a/test.sh
+++ b/test.sh
@@ -97,6 +97,20 @@ testUsages2() {
     assertEquals '' "$(echo -e "id1\tid2\t1" | sort)" "$(cat "$TMPDIR/deps.tsv" | sort)"
 }
 
+testCleanUpFgrepTwoOnSameLine() {
+    local file="$(mktemp)"
+    echo "hit hit" > "$file"
+
+    out=$(fgrep --color=never -H -o -f <(echo "hit") "$file" \
+        | clean_up_fgrep)
+
+    read -r -d '' expected <<- EOF
+		${file}:hit
+		${file}:hit
+	EOF
+    assertEquals '' "$expected" "$out"
+}
+
 testNoParameters() {
     local out="$(main 2>&1)"
 


### PR DESCRIPTION
If a file references multiple "some.dependency.package" or another on the same line,
fgrep -H -o outputs:
    file:match
    match
instead of the expected:
    file:match
    file:match

Side node:
fgrep -H -o -f <(echo -e "A\nB") <<< BA
seems to miss one match (B),
while AB gets them both.