### PR TITLE
Add option -s

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -142,6 +142,7 @@ testArgumentHelp() {
 		                [groupId]:[artifactId]:[type]:[version]
 		  -o filename   Write output to file
 		  -u            Don't check all undeclared dependencies
+		  -s            Don't check string dependencies (only maven)
 		  -q            Quiet
 	EOF
     assertEquals "$expected" "$out"


### PR DESCRIPTION
When package names are far from unique, it may not make sense to do
string matching of package names to find dependency usages.

Warning: One should usually not set both of -s, -u